### PR TITLE
Fix install-lib symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install-headers:
 
 install-lib:
 	cp $(TARGET) $(DESTDIR)$(PREFIX)/lib/
-	ln -sf $(DESTDIR)$(PREFIX)/lib/$(TARGET) $(DESTDIR)$(PREFIX)/lib/$(LIBNAME)$(LIBEXT)
+	ln -sf $(TARGET) $(DESTDIR)$(PREFIX)/lib/$(LIBNAME)$(LIBEXT)
 
 install: $(TARGET) install-headers install-lib
 


### PR DESCRIPTION
Symlink should be relative, otherwise when installing via buildroot we end up with an absolute symlink pointing to the host filesystem (which doesn't exist on the device).