### PR TITLE
error.c: Fix typo

### DIFF
--- a/src/common/error.c
+++ b/src/common/error.c
@@ -8,7 +8,7 @@ Shake_Status Shake_EmitErrorCode(Shake_ErrorCode ec)
 	return SHAKE_ERROR;
 }
 
-Shake_ErrorCode Shake_GetErrorCod(void)
+Shake_ErrorCode Shake_GetErrorCode(void)
 {
 	return errorCode;
 }


### PR DESCRIPTION
Fix typo in error.c
Not sure how this wasn't a link error